### PR TITLE
HOLD FOR 2024 - Changes to Playoff Schedule

### DIFF
--- a/shared/DoubleEliminationBracketMapping.ts
+++ b/shared/DoubleEliminationBracketMapping.ts
@@ -228,7 +228,7 @@ const DoubleEliminationBracketMapping: BracketMapping = {
       },
     },
   ],
-  breakAfter: [4, 8, 10, 12, 13],
+  breakAfter: [10, 12, 13],
 };
 
 export default DoubleEliminationBracketMapping;


### PR DESCRIPTION
<https://www.firstinspires.org/robotics/frc/blog/2023-double-elimination-2023-data-and-updates#:~:text=Removes%20the%20first%20two%20breaks%20entirely>